### PR TITLE
Fix npm install step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '16'
 
-      - run: npm ci
+      - run: npm install
 
       - run: npm run build
 


### PR DESCRIPTION
## Summary
- change `npm ci` to `npm install` in GitHub Actions deploy workflow

## Testing
- `npm install` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68628e0a891883208b56a3a4ade31404